### PR TITLE
1.72 update for build 3717

### DIFF
--- a/cmake/gtav-classes.cmake
+++ b/cmake/gtav-classes.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     gtav_classes
     GIT_REPOSITORY https://github.com/Mr-X-GTA/GTAV-Classes-1.git
-    GIT_TAG        98d4999a7f893d1ebbed7a4852599895afeadef1
+    GIT_TAG        b74e688860b0df47d7ec87c1eb6227ee853fc90a
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/backend/commands/player/misc/enter_interior.cpp
+++ b/src/backend/commands/player/misc/enter_interior.cpp
@@ -32,11 +32,11 @@ namespace big
 			}
 			else if (scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[id].SimpleInteriorData.Index != eSimpleInteriorIndex::SIMPLE_INTERIOR_INVALID)
 			{
-				*scr_globals::interiors.at(3824).as<Player*>() =
+				*scr_globals::interiors.at(3891).as<Player*>() =
 				    scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[id].SimpleInteriorData.Owner;
-				*scr_globals::interiors.at(4178).as<eSimpleInteriorIndex*>() =
+				*scr_globals::interiors.at(4248).as<eSimpleInteriorIndex*>() =
 				    scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[id].SimpleInteriorData.Index;
-				*scr_globals::interiors.at(4177).as<bool*>() = true;
+				*scr_globals::interiors.at(4247).as<bool*>() = true;
 				scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id].SimpleInteriorData.InteriorSubtype =
 				    scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[id].SimpleInteriorData.InteriorSubtype;
 			}

--- a/src/backend/looped/self/fast_respawn.cpp
+++ b/src/backend/looped/self/fast_respawn.cpp
@@ -14,13 +14,13 @@ namespace big
 			*scr_globals::disable_wasted_sound.as<bool*>() = true;
 
 			// triggers respawn instantly upon death, has no effect if not respawning so no need to check if the player's dead
-			misc::set_bit(&(*scr_globals::freemode_properties.at(1761).at(756).as<int*>()), 1); // Update: freemode -> KILL_STRIP_H -> Above that = "!IS_BIT_SET(global, 2)"
+			misc::set_bit(&(*scr_globals::freemode_properties.at(1762).at(756).as<int*>()), 1); // Update: freemode -> KILL_STRIP_H -> Above that = "!IS_BIT_SET(global, 2)"
 		}
 
 		virtual void on_disable() override
 		{
 			*scr_globals::disable_wasted_sound.as<bool*>() = false;
-			misc::clear_bit(&(*scr_globals::freemode_properties.at(1761).at(756).as<int*>()), 1); 
+			misc::clear_bit(&(*scr_globals::freemode_properties.at(1762).at(756).as<int*>()), 1); 
 		}
 	};
 

--- a/src/backend/looped/self/off_radar.cpp
+++ b/src/backend/looped/self/off_radar.cpp
@@ -15,7 +15,7 @@ namespace big
 		{
 			if (g.self.ghost_org)
 			{
-				MISC::SET_BIT(scr_globals::freemode_global.at(4704).as<int*>(), 2);
+				MISC::SET_BIT(scr_globals::freemode_global.at(3758).as<int*>(), 2);
 			}
 			scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id].OffRadarActive = true;
 			*scr_globals::freemode_properties.at(58).as<int*>() = NETWORK::GET_NETWORK_TIME() + 1;
@@ -25,7 +25,7 @@ namespace big
 		{
 			if (!g.self.ghost_org)
 			{
-				MISC::CLEAR_BIT(scr_globals::freemode_global.at(4704).as<int*>(), 2);
+				MISC::CLEAR_BIT(scr_globals::freemode_global.at(3758).as<int*>(), 2);
 			}
 			scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id].OffRadarActive = false;
 		}

--- a/src/backend/script_patches.hpp
+++ b/src/backend/script_patches.hpp
@@ -17,8 +17,8 @@ namespace big
 		g_script_patcher_service->add_patch({"freemode"_J, "disable population load balancing", "2D 00 07 00 00 7B", 5, {0x2E, 0x00, 0x00}, nullptr}); // disable population load balancing
 		g_script_patcher_service->add_patch(
 		    {"freemode"_J, "freemode7", "2D 02 08 00 00 38 01 56", 5, {0x2E, 0x02, 0x00}, &g.session.block_muggers});
-		//g_script_patcher_service->add_patch(
-		//    {"freemode"_J, "freemode8", "2D 00 CF 00 00", 5, {0x2E, 0x00, 0x00}, &g.session.block_ceo_raids}); // doesn't work
+		g_script_patcher_service->add_patch(
+		    {"freemode"_J, "freemode8", "2D 00 D0 00 00 5D", 5, {0x2E, 0x00, 0x00}, &g.session.block_ceo_raids}); // doesn't work
 		g_script_patcher_service->add_patch(
 		    {"freemode"_J, "prevent normal blip update", "06 56 ? ? 38 02 2C ? ? ? 71 71", 0, {0x2B, 0x55}, &g.spoofing.spoof_blip}); // prevent normal blip update
 		g_script_patcher_service->add_patch({"freemode"_J,

--- a/src/core/scr_globals.hpp
+++ b/src/core/scr_globals.hpp
@@ -10,7 +10,6 @@ namespace big::scr_globals
 
 	static inline const script_global globalplayer_bd(2658291);
 	static inline const script_global gpbd_fm_3(1892653);
-
 	static inline const script_global gpbd_fm_1(1845250);
 	static inline const script_global interiors(1950198);
 
@@ -43,7 +42,7 @@ namespace big::scr_globals
 	static inline const script_global session5(1575017);
 	static inline const script_global session6(2696922); // freemode -> if (NETWORK::NETWORK_IS_GAME_IN_PROGRESS() && !NETWORK::NETWORK_IS_ACTIVITY_SESSION())
 
-	static inline const script_global interaction_menu_access(2711261); // am_pi_menu -> if (NETWORK::NETWORK_IS_SIGNED_ONLINE()) first global after that
+	static inline const script_global interaction_menu_access(2712075); // am_pi_menu -> if (NETWORK::NETWORK_IS_SIGNED_ONLINE()) first global after that
 
 	static inline const script_global disable_wasted_sound(2708893); // freemode -> AUDIO::PLAY_SOUND_FRONTEND(-1, "Wasted", "POWER_PLAY_General_Soundset", true);
 
@@ -65,35 +64,35 @@ namespace big::scr_locals
 {
 	namespace am_hunt_the_beast
 	{
-		constexpr static auto broadcast_idx        = 624;  // (bParam0) != 0;
-		constexpr static auto player_broadcast_idx = 2608; // if (NETWORK::PARTICIPANT_ID_TO_INT() != -1)
+		constexpr static auto broadcast_idx        = 626;  // (bParam0) != 0;
+		constexpr static auto player_broadcast_idx = 2610; // if (NETWORK::PARTICIPANT_ID_TO_INT() != -1)
 	}
 
 	namespace am_criminal_damage
 	{
-		constexpr static auto broadcast_idx = 119; // /* Tunable: CRIMINAL_DAMAGE_DISABLE_SHARE_CASH */)
-		constexpr static auto score_idx = 114; // AUDIO::PLAY_SOUND_FRONTEND(-1, "Criminal_Damage_High_Value", "GTAO_FM_Events_Soundset", false);
+		constexpr static auto broadcast_idx = 121; // /* Tunable: CRIMINAL_DAMAGE_DISABLE_SHARE_CASH */)
+		constexpr static auto score_idx = 116; // AUDIO::PLAY_SOUND_FRONTEND(-1, "Criminal_Damage_High_Value", "GTAO_FM_Events_Soundset", false);
 	}
 
 	namespace am_cp_collection
 	{
-		constexpr static auto broadcast_idx = 824; // bVar1 = NETWORK::NETWORK_GET_PLAYER_INDEX(PLAYER::INT_TO_PARTICIPANTINDEX(iVar0));
-		constexpr static auto player_broadcast_idx = 3465; // bVar1 = NETWORK::NETWORK_GET_PLAYER_INDEX(PLAYER::INT_TO_PARTICIPANTINDEX(iVar0));
+		constexpr static auto broadcast_idx = 826; // bVar1 = NETWORK::NETWORK_GET_PLAYER_INDEX(PLAYER::INT_TO_PARTICIPANTINDEX(iVar0));
+		constexpr static auto player_broadcast_idx = 3467; // bVar1 = NETWORK::NETWORK_GET_PLAYER_INDEX(PLAYER::INT_TO_PARTICIPANTINDEX(iVar0));
 	}
 
 	namespace am_king_of_the_castle
 	{
-		constexpr static auto broadcast_idx = 102; // KING_OF_THE_CASTLE_EVENT_TIME_LIMIT
+		constexpr static auto broadcast_idx = 104; // KING_OF_THE_CASTLE_EVENT_TIME_LIMIT
 	}
 
 	namespace fmmc_launcher
 	{
-		constexpr static auto broadcast_idx = 12827; // if (NETWORK::NETWORK_IS_PLAYER_ACTIVE(PLAYER::INT_TO_PLAYERINDEX(Global_
+		constexpr static auto broadcast_idx = 12888; // if (NETWORK::NETWORK_IS_PLAYER_ACTIVE(PLAYER::INT_TO_PLAYERINDEX(Global_
 	}
 
 	namespace fm_mission_controller
 	{
-		constexpr static auto mission_controller_wanted_state_flags = 60892; // if (PLAYER::GET_PLAYER_WANTED_LEVEL(bLocal_
+		constexpr static auto mission_controller_wanted_state_flags = 60898; // if (PLAYER::GET_PLAYER_WANTED_LEVEL(bLocal_
 	}
 
 	namespace freemode

--- a/src/hooks/protections/can_apply_data.cpp
+++ b/src/hooks/protections/can_apply_data.cpp
@@ -461,13 +461,14 @@ namespace big
 			LOG_FIELD_B(CTrainGameStateDataNode, m_direction);
 			LOG_FIELD_B(CTrainGameStateDataNode, m_has_passenger_carriages);
 			LOG_FIELD_B(CTrainGameStateDataNode, m_render_derailed);
-			LOG_FIELD_B(CTrainGameStateDataNode, unk_00C6);
 			LOG_FIELD_B(CTrainGameStateDataNode, unk_00C7);
+			LOG_FIELD_B(CTrainGameStateDataNode, new_00C8);
 			LOG_FIELD_NI(CTrainGameStateDataNode, m_engine_id);
 			LOG_FIELD_C(CTrainGameStateDataNode, m_train_config_index);
 			LOG_FIELD_C(CTrainGameStateDataNode, m_carriage_config_index);
 			LOG_FIELD_C(CTrainGameStateDataNode, m_track_id);
 			LOG_FIELD(CTrainGameStateDataNode, m_distance_from_engine);
+			LOG_FIELD(CTrainGameStateDataNode, new_00D4);
 			LOG_FIELD(CTrainGameStateDataNode, m_cruise_speed);
 			LOG_FIELD_NI(CTrainGameStateDataNode, m_linked_to_backward_id);
 			LOG_FIELD_NI(CTrainGameStateDataNode, m_linked_to_forward_id);

--- a/src/services/mobile/mobile_service.cpp
+++ b/src/services/mobile/mobile_service.cpp
@@ -157,7 +157,7 @@ namespace big
 		{
 		case 12: //Hangar
 		{
-			auto hangar_id = *scr_globals::gpbd_fm_1.at(self::id, 874).at(260).at(298).as<PINT>();
+			auto hangar_id = *scr_globals::gpbd_fm_1.at(self::id, 880).at(260).at(304).as<PINT>();
 			switch (hangar_id)
 			{
 			case 1: return HUD::GET_FILENAME_FOR_AUDIO_CONVERSATION("MP_HANGAR_1"); //LSIA Hangar 1
@@ -170,7 +170,7 @@ namespace big
 		}
 		case 13: //Facility
 		{
-			auto facility_id = *scr_globals::gpbd_fm_1.at(self::id, 874).at(260).at(305).as<PINT>();
+			auto facility_id = *scr_globals::gpbd_fm_1.at(self::id, 880).at(260).at(311).as<PINT>();
 			switch (facility_id)
 			{
 			case 1: return HUD::GET_FILENAME_FOR_AUDIO_CONVERSATION("MP_DBASE_1");  //Grand Senora Desert Facility

--- a/src/util/mobile.hpp
+++ b/src/util/mobile.hpp
@@ -30,7 +30,7 @@ namespace big::mobile
 	{
 		inline void request_ammo_drop()
 		{
-			*scr_globals::freemode_global.at(548).as<int*>() = 1; // REGEX: if \(Global_.*?.f_.*?\)\n.*?\{\n.*?if \(!NETWORK::NETWORK_IS_SCRIPT_ACTIVE\("AM_AMMO_DROP", PLAYER::PLAYER_ID\(\), true, 0\)\)
+			*scr_globals::freemode_global.at(538).as<int*>() = 1; // REGEX: if \(Global_.*?.f_.*?\)\n.*?\{\n.*?if \(!NETWORK::NETWORK_IS_SCRIPT_ACTIVE\("AM_AMMO_DROP", PLAYER::PLAYER_ID\(\), true, 0\)\)
 		}
 
 		inline void request_boat_pickup()
@@ -106,7 +106,7 @@ namespace big::mobile
 	{
 		inline void request_avenger()
 		{
-			*scr_globals::freemode_global.at(594).as<int*>() = 1; // Look for if (IS_BIT_SET(Global_.*?.f_.*?, 1)) { BUNCH OF CODE BETWEEN if (!ENTITY::IS_ENTITY_DEAD(vehicle2, false))
+			*scr_globals::freemode_global.at(585).as<int*>() = 1; // Look for if (IS_BIT_SET(Global_.*?.f_.*?, 1)) { BUNCH OF CODE BETWEEN if (!ENTITY::IS_ENTITY_DEAD(vehicle2, false))
 		}
 
 		inline void request_kosatka()
@@ -174,7 +174,7 @@ namespace big::mobile
 			// only do this when spawn inside is enabled otherwise the vehicle will spawn relatively far away from players
 			if (g.clone_pv.spawn_inside)
 			{
-				*scr_globals::freemode_global.at(969).as<int*>() = 1; // disable vehicle node distance check
+				*scr_globals::freemode_global.at(590).as<int*>() = 1; // disable vehicle node distance check
 			}
 			*scr_globals::freemode_global.at(575).as<int*>() = 1; // tell freemode to spawn our vehicle | HOW TO FIND: https://imgur.com/8q2P1wB
 			*scr_globals::freemode_global.at(641).as<int*>() = 0; // required | REGEX: if \(BUILTIN::VDIST2\(.*?\) > 50f \* 50f && !Global_.*?.f_.*?\)
@@ -206,7 +206,7 @@ namespace big::mobile
 	{
 		inline void request_taxi()
 		{
-			*scr_globals::freemode_global.at(880).as<int*>() = 1;
+			*scr_globals::freemode_global.at(509).as<int*>() = 1;
 		}
 
 		inline void request_gun_van()

--- a/src/util/outfit.hpp
+++ b/src/util/outfit.hpp
@@ -65,26 +65,26 @@ namespace big::outfit
 	// usually each update increases 1//
 	inline char* get_slot_name_address(int slot)
 	{
-		return scr_globals::stats.at(0, 5571).at(681).at(2463).at(slot, 8).as<char*>();
+		return scr_globals::stats.at(0, 5574).at(681).at(2466).at(slot, 8).as<char*>();
 	}
 
 	inline int* get_component_drawable_id_address(int slot, int id)
 	{
-		return scr_globals::stats.at(0, 5571).at(681).at(1339).at(slot, 13).at(id, 1).as<int*>();
+		return scr_globals::stats.at(0, 5574).at(681).at(1342).at(slot, 13).at(id, 1).as<int*>();
 	}
 
 	inline int* get_component_texture_id_address(int slot, int id)
 	{
-		return scr_globals::stats.at(0, 5571).at(681).at(1613).at(slot, 13).at(id, 1).as<int*>();
+		return scr_globals::stats.at(0, 5574).at(681).at(1616).at(slot, 13).at(id, 1).as<int*>();
 	}
 
 	inline int* get_prop_drawable_id_address(int slot, int id)
 	{
-		return scr_globals::stats.at(0, 5571).at(681).at(1887).at(slot, 10).at(id, 1).as<int*>();
+		return scr_globals::stats.at(0, 5574).at(681).at(1890).at(slot, 10).at(id, 1).as<int*>();
 	}
 
 	inline int* get_prop_texture_id_address(int slot, int id)
 	{
-		return scr_globals::stats.at(0, 5571).at(681).at(2098).at(slot, 10).at(id, 1).as<int*>();
+		return scr_globals::stats.at(0, 5574).at(681).at(2101).at(slot, 10).at(id, 1).as<int*>();
 	}
 }

--- a/src/util/session.hpp
+++ b/src/util/session.hpp
@@ -68,8 +68,8 @@ namespace big::session
 	{
 		int idx = index / 32;
 		int bit = index % 32;
-		misc::set_bit(scr_globals::gsbd_fm_events.at(11).at(397).at(idx, 1).as<int*>(), bit);
-		misc::set_bit(scr_globals::gsbd_fm_events.at(11).at(387).at(idx, 1).as<int*>(), bit);
+		misc::set_bit(scr_globals::gsbd_fm_events.at(11).at(402).at(idx, 1).as<int*>(), bit);
+		misc::set_bit(scr_globals::gsbd_fm_events.at(11).at(392).at(idx, 1).as<int*>(), bit);
 		misc::set_bit((int*)&scr_globals::gpbd_fm_3.as<GPBD_FM_3*>()->Entries[self::id].BossGoon.ActiveFreemodeEvents[idx], bit);
 	}
 
@@ -77,8 +77,8 @@ namespace big::session
 	{
 		int idx = index / 32;
 		int bit = index % 32;
-		misc::clear_bit(scr_globals::gsbd_fm_events.at(11).at(397).at(idx, 1).as<int*>(), bit);
-		misc::clear_bit(scr_globals::gsbd_fm_events.at(11).at(387).at(idx, 1).as<int*>(), bit);
+		misc::clear_bit(scr_globals::gsbd_fm_events.at(11).at(402).at(idx, 1).as<int*>(), bit);
+		misc::clear_bit(scr_globals::gsbd_fm_events.at(11).at(392).at(idx, 1).as<int*>(), bit);
 		misc::clear_bit((int*)&scr_globals::gpbd_fm_3.as<GPBD_FM_3*>()->Entries[self::id].BossGoon.ActiveFreemodeEvents[idx], bit);
 	}
 


### PR DESCRIPTION
This commit updates various global indices, offsets, and script patch patterns throughout the codebase to match the latest GTA V patch. Changes include adjustments in interior handling, respawn logic, off-radar toggling, script patching, mobile services, outfit management, and session event bitfields. Also updates the GTAV-Classes submodule to a newer commit and adds new fields to CTrainGameStateDataNode logging.